### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -18,7 +18,7 @@ jobs:
         id: context
         shell: sh
         run: |
-          echo "::set-output name=label::run-${{ github.run_id }}-${{ github.run_number }}"
+          echo "label=run-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_OUTPUT
           case "${{ github.ref_name }}" in
             main)
               echo "branch=create-pr-action/run-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -21,10 +21,10 @@ jobs:
           echo "::set-output name=label::run-${{ github.run_id }}-${{ github.run_number }}"
           case "${{ github.ref_name }}" in
             main)
-              echo "::set-output name=branch::create-pr-action/run-${{ github.run_id }}-${{ github.run_number }}"          
+              echo "branch=create-pr-action/run-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_OUTPUT
             ;;
             *)
-              echo "::set-output name=branch::${{ github.ref_name }}"
+              echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
             ;;
           esac
 


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/