### PR TITLE
feat: support environments with hyphens

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
         compact: true
         raw-output: true
         input: ${{ inputs.labels_env }}
-        script: ${{ format('.{0}', inputs.env) }}
+        script: ${{ format('."{0}"', inputs.env) }}
 
     - uses: actions/github-script@v7
       with:


### PR DESCRIPTION
## what
* Quote `env` so `jq` interprets it properly as a key

## why
* We have a use case where our preview environments contain a hyphen
* The cleanup step fails because `jq` misinterprets the key

```bash
% echo '{"preview-foo": "deploy/preview"}' | jq -cr '.preview-foo'
jq: error: foo/0 is not defined at <top-level>, line 1, column 10:
    .preview-foo
             ^^^
jq: 1 compile error
```

vs.

```bash
% echo '{"preview-foo": "deploy/preview"}' | jq -cr '."preview-foo"'
deploy/preview
```
