### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -49,7 +49,7 @@ jobs:
           PR_BRANCH_NAME: '${{ steps.context.outputs.label }}'
           PR_TITLE: 'Test ${{ steps.context.outputs.label }}'
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: pr
         with:
           script: |
@@ -78,14 +78,14 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: snnaplab/get-labels-action@v1
         id: labels
         with:
           number: ${{ needs.setup.outputs.pr_number }}
 
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           comparison: "contains"
           expected: "${{ needs.setup.outputs.label }}"
@@ -107,7 +107,7 @@ jobs:
         with:
           number: ${{ needs.setup.outputs.pr_number }}
 
-      - uses: nick-fields/assert-action@v1
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           comparison: "notContains"
           expected: "${{ needs.setup.outputs.label }}"
@@ -121,7 +121,7 @@ jobs:
       - name: Tear down
         run: echo "Do Tear down"
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const label = '${{ needs.setup.outputs.label }}';
@@ -142,7 +142,7 @@ jobs:
               console.log(`Label ${label} was not found on PR #${prNumber}`);
             }
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: ${{ github.ref_name == 'main' }}
         with:
           script: |

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
         input: ${{ inputs.labels_env }}
         script: ${{ format('."{0}"', inputs.env) }}
 
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const label = '${{ steps.label.outputs.output }}';

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - uses: cloudposse/github-action-jq@0.4.0
+    - uses: cloudposse/github-action-jq@aff18a1f2e845b56fcfe995b01a558836dc2025b # v0.4.1
       id: label
       with:
         compact: true


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v3` → `@3d3c42e5...` `# v7.0.1`
  * `actions/github-script@v6|v7` → `@3a2844b7...` `# v9.0.0`
  * `nick-fields/assert-action@v1` → `@0efd6166...` `# v4.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #50
Supersedes #49
Supersedes #47

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
